### PR TITLE
Easy save image on pc

### DIFF
--- a/browser/js/funcs.js
+++ b/browser/js/funcs.js
@@ -265,3 +265,14 @@ function getLoadingGif () {
 
   return loadingGIF;
 }
+
+function downloadFile(urlOfFile) {
+  var element = document.createElement('a');
+  element.setAttribute('href', urlOfFile);
+  element.setAttribute('download', true);
+  element.style.display = 'none';
+
+  document.body.appendChild(element);
+  element.click();
+  document.body.removeChild(element);
+}

--- a/browser/js/renderers.js
+++ b/browser/js/renderers.js
@@ -224,11 +224,16 @@ function renderContextMenu (text) {
 
 function renderImageContextMenu (url) {
   const menu = new Menu();
-  const menuItem = new MenuItem({
+  const copyImageUrl = new MenuItem({
     label: 'Copy URL to clipboard',
     click: () => copyToCliboard(url)
   });
-  menu.append(menuItem);
+  const saveItem = new MenuItem({
+    label: 'Save image as...',
+    click: () => downloadFile(url)
+  });
+  menu.append(copyImageUrl);
+  menu.append(saveItem);
   menu.popup({});
 }
 


### PR DESCRIPTION
Images from instagram api are received as jpg.

Steps to download :
1. Right click on any image (.jpg/.jpeg) file.
2. Click on 'Save image as...'
3. Select the path to save.

Closes: #1225

Preview: 

![save-image](https://user-images.githubusercontent.com/15632559/75618667-af739b80-5b97-11ea-8dfd-84d046fe89b7.gif)
