### PR TITLE
Reset text area after message is sent

### DIFF
--- a/browser/js/funcs.js
+++ b/browser/js/funcs.js
@@ -117,6 +117,15 @@ function markAsRead (id, li) {
   li.classList.remove('notification');
 }
 
+function resetMessageTextArea(){
+  var input = document.querySelector(MSG_INPUT_SELECTOR);
+  input.value = '';
+
+  var event = document.createEvent('Event');
+  event.initEvent('input', true, true);
+  input.dispatchEvent(event);
+}
+
 function sendMessage (message, accounts, chatId) {
   const isNewChat = !chatId;
   var users = accounts.map((account) => account.id);
@@ -128,7 +137,7 @@ function submitMessage (chat_) {
   var message = input.value;
   if (message.trim()) {
     sendMessage(message, chat_.accounts, chat_.id);
-    input.value = '';
+    resetMessageTextArea();
     var div = renderMessage(message, 'outward');
     var msgContainer = document.querySelector('.chat .messages');
 


### PR DESCRIPTION
Closes: #1129 

After sending the message the text area remained the same size.

**Steps:**  
1. A **New Event** of "input" should be dispatched in the _element/text-area_ when we reset the text which will resize textarea. 
 
![reset-textarea](https://user-images.githubusercontent.com/15632559/75634936-016bfe00-5c38-11ea-9278-cc3015aee1a5.gif)
