### PR TITLE
Play Video in a carousel. 

### DIFF
--- a/browser/css/app.css
+++ b/browser/css/app.css
@@ -579,6 +579,10 @@ EMOJIS
 CAROUSEL
 ******************************/
 
+.carousel {
+  position: inherit;
+}
+
 .carousel-left, .carousel-right {
   position: absolute;
   padding: 40px;

--- a/browser/js/carousel.js
+++ b/browser/js/carousel.js
@@ -1,6 +1,6 @@
-window.carouselInit = (element, images) => {
+window.carouselInit = (element, media) => {
   const carousel = dom('<div class="carousel"></div>');
-  let activeImage = 0;
+  let activeMedia = 0;
   const leftButton = dom('<button class="carousel-left"></button>');
   const rightButton = dom('<button class="carousel-right"></button>');
   element.appendChild(carousel);
@@ -8,15 +8,16 @@ window.carouselInit = (element, images) => {
   element.appendChild(rightButton);
 
   leftButton.onclick = () => {
-    activeImage--;
-    activeImage = activeImage < 0 ? images.length - 1 : activeImage;
-    carousel.innerHTML = `<img src="${images[activeImage]}">`;
+    activeMedia--;
+    activeMedia = activeMedia < 0 ? media.length - 1 : activeMedia;
+    carousel.innerHTML = getHTMLElement(media[activeMedia]);
   }
 
   rightButton.onclick = () => {
-    activeImage++;
-    activeImage = activeImage > images.length - 1 ? 0 : activeImage;
-    carousel.innerHTML = `<img src="${images[activeImage]}">`;
+    activeMedia++;
+    activeMedia = activeMedia > media.length - 1 ? 0 : activeMedia;
+    carousel.innerHTML = getHTMLElement(media[activeMedia]);
   }
-  carousel.innerHTML = `<img src="${images[activeImage]}">`;
+
+  carousel.innerHTML = getHTMLElement(media[activeMedia]);
 }

--- a/browser/js/funcs.js
+++ b/browser/js/funcs.js
@@ -285,3 +285,15 @@ function downloadFile(urlOfFile) {
   element.click();
   document.body.removeChild(element);
 }
+
+function getHTMLElement(media) {
+  var mediaContent;
+  if (media.videos) {
+    mediaContent = `<video width="${media.videos[0].width}" controls>
+      <source src="${media.videos[0].url}" type="video/mp4">
+    </video>`;
+  } else {
+    mediaContent = `<img src="${media.images[0].url}">`;
+  }
+  return mediaContent;
+}

--- a/browser/js/renderers.js
+++ b/browser/js/renderers.js
@@ -83,7 +83,7 @@ function renderPost (post) {
                                 <source src="${post.videos[0].url}" type="video/mp4">
                               </video>`));
   } else if (post.carouselMedia && post.carouselMedia.length) {
-    window.carouselInit(postDom, post.images.map((el) => el[0].url))
+    window.carouselInit(postDom, post.carouselMedia.map((el) => el._params))
   } else {
     postDom.appendChild(dom(`<img src="${post.images[0].url}"/>`));
   }


### PR DESCRIPTION
If we share a post with mutliple mediatype, i.e. post containing images/videos. _Videos_ are not rendered when we click on the post which renders in **Carousel**.
**As explained in the issue : #1210** 

Closes: #1210 

![carousel](https://user-images.githubusercontent.com/15632559/75675751-c2788f80-5cad-11ea-8548-fdc979853706.gif)
