### PR TITLE
[Feat] Optional update of IG:dm

### DIFF
--- a/main/main.js
+++ b/main/main.js
@@ -6,6 +6,7 @@ const url = require('url');
 const instagram = require('./instagram');
 const autoUpdater = require('./autoupdater');
 const client = require('electron-connect').client;
+const {autoUpdatePreference} = require('./userpreferences');
 
 // fixes electron's timeout inconsistency
 // not doing this on windows because the fix doesn't work for windows.
@@ -181,7 +182,9 @@ app.on('ready', () => {
       Menu.setApplicationMenu(menu);
     });
   }
-  autoUpdater.init();
+  if (autoUpdatePreference.autoUpdateStatus) {
+    autoUpdater.init();
+  }
 });
 
 app.on('window-all-closed', () => {

--- a/main/menutemplate.js
+++ b/main/menutemplate.js
@@ -110,7 +110,7 @@ if (process.platform === 'darwin') {
 const createMenuTemplate = () => {
   return new Promise((resolve) => {
     autoLaunch.autoLaunchStatus().then((autoLaunchStatus) => {
-      template.push(
+      template.splice(-2, 0,
         {
           label: 'Configurations',
           submenu: [

--- a/main/menutemplate.js
+++ b/main/menutemplate.js
@@ -1,6 +1,7 @@
 const app = require('electron').app;
 const { openExternal } = require('electron').shell;
 const autoLaunch = require('./autolaunch');
+const { autoUpdatePreference } = require('./userpreferences');
 
 const template = [
   {
@@ -108,7 +109,7 @@ if (process.platform === 'darwin') {
 
 const createMenuTemplate = () => {
   return new Promise((resolve) => {
-    autoLaunch.autoLaunchStatus().then((status) => {
+    autoLaunch.autoLaunchStatus().then((autoLaunchStatus) => {
       template.push(
         {
           label: 'Configurations',
@@ -116,8 +117,14 @@ const createMenuTemplate = () => {
             {
               label: 'Auto-Launch',
               type: 'checkbox',
-              checked: status,
+              checked: autoLaunchStatus,
               click () { autoLaunch.toggleAutoLaunch(); }
+            },
+            {
+              label: 'Auto-Update',
+              type: 'checkbox',
+              checked: autoUpdatePreference.autoUpdateStatus,
+              click () { autoUpdatePreference.toggleAutoUpdate(); }
             }
           ]
         }

--- a/main/storage.js
+++ b/main/storage.js
@@ -1,0 +1,31 @@
+const electron = require('electron');
+const path = require('path');
+const fs = require('fs');
+
+function parseDataFile (filePath, defaults) {
+  // We'll try/catch it in case the file doesn't exist yet, which will be the case on the first application run.
+  // `fs.readFileSync` will return a JSON string which we then parse into a Javascript object
+  try {
+    return JSON.parse(fs.readFileSync(filePath));
+  } catch (error) {
+    // if there was some kind of error, return the passed in defaults instead.
+    return defaults;
+  }
+}
+
+const Store = function (storeProps) {
+  const userDataPath = (electron.app || electron.remote.app).getPath('userData');
+  this.path = path.join(userDataPath, storeProps.configName + '.json');
+  this.data = parseDataFile(this.path, storeProps.defaults);
+
+  this.get = function (key) {
+    return this.data[key];
+  };
+
+  this.set = function (key, value) {
+    this.data[key] = value;
+    fs.writeFileSync(this.path, JSON.stringify(this.data));
+  };
+};
+
+module.exports = Store;

--- a/main/storage.js
+++ b/main/storage.js
@@ -1,31 +1,35 @@
 const electron = require('electron');
 const path = require('path');
 const fs = require('fs');
+const utils = require('./utils');
 
 function parseDataFile (filePath, defaults) {
-  // We'll try/catch it in case the file doesn't exist yet, which will be the case on the first application run.
-  // `fs.readFileSync` will return a JSON string which we then parse into a Javascript object
   try {
-    return JSON.parse(fs.readFileSync(filePath));
+    if (utils.canUseFileStorage()) {
+      return JSON.parse(fs.readFileSync(filePath));
+    } else {
+      return defaults;
+    }
   } catch (error) {
-    // if there was some kind of error, return the passed in defaults instead.
     return defaults;
   }
 }
 
-const Store = function (storeProps) {
-  const userDataPath = (electron.app || electron.remote.app).getPath('userData');
-  this.path = path.join(userDataPath, storeProps.configName + '.json');
-  this.data = parseDataFile(this.path, storeProps.defaults);
-};
+class Store {
+  constructor (storeProps) {
+    const userDataPath = (electron.app || electron.remote.app).getPath('userData');
+    this.path = path.join(userDataPath, storeProps.configName + '.store');
+    this.data = parseDataFile(this.path, storeProps.defaults);
+  }
 
-Store.prototype.get = function (key) {
-  return this.data[key];
-};
+  get (key) {
+    return this.data[key];
+  }
 
-Store.prototype.set = function (key, value) {
-  this.data[key] = value;
-  fs.writeFileSync(this.path, JSON.stringify(this.data));
-};
+  set (key, value) {
+    this.data[key] = value;
+    fs.writeFileSync(this.path, JSON.stringify(this.data));
+  }
+}
 
 module.exports = Store;

--- a/main/storage.js
+++ b/main/storage.js
@@ -17,15 +17,15 @@ const Store = function (storeProps) {
   const userDataPath = (electron.app || electron.remote.app).getPath('userData');
   this.path = path.join(userDataPath, storeProps.configName + '.json');
   this.data = parseDataFile(this.path, storeProps.defaults);
+};
 
-  this.get = function (key) {
-    return this.data[key];
-  };
+Store.prototype.get = function (key) {
+  return this.data[key];
+};
 
-  this.set = function (key, value) {
-    this.data[key] = value;
-    fs.writeFileSync(this.path, JSON.stringify(this.data));
-  };
+Store.prototype.set = function (key, value) {
+  this.data[key] = value;
+  fs.writeFileSync(this.path, JSON.stringify(this.data));
 };
 
 module.exports = Store;

--- a/main/userpreferences.js
+++ b/main/userpreferences.js
@@ -1,0 +1,20 @@
+const Store = require('./storage');
+
+const userPreferences = new Store({
+  configName: 'user-preferences',
+  defaults: {
+    AUTO_UPDATE : true,
+  },
+});
+
+const autoUpdatePreference = {
+  autoUpdateStatus: userPreferences.get('AUTO_UPDATE'),
+  toggleAutoUpdate: function () {
+    const status = userPreferences.get('AUTO_UPDATE');
+    userPreferences.set('AUTO_UPDATE', !status);
+  }
+};
+
+module.exports = {
+  autoUpdatePreference,
+};


### PR DESCRIPTION
**Feature:** Enable/Disable check for auto-update.

**Description:** Auto-update to the new release is always _ON_ by default. This feature checks saved user-preference and updates only when Auto-update is enabled. 

**Preview:**

![auto-update](https://user-images.githubusercontent.com/15632559/76435177-adea7480-63dc-11ea-9f04-f1b621afb21f.gif)

__** WHATS NEW ? **__
**Storage API:** Introducing to storage.js which can help developer to store user preferences and can create new store to save/preserve data specific to each user.  

Closes: #1240 , #444 