### PR TITLE
[Fix] Rendering issue while sending multiple messages in short delay

### DIFF
--- a/browser/js/funcs.js
+++ b/browser/js/funcs.js
@@ -126,21 +126,26 @@ function resetMessageTextArea () {
   input.dispatchEvent(event);
 }
 
-function sendMessage (message, accounts, chatId) {
+function sendMessage (message, accounts, chatId, trackerKey) { 
   const isNewChat = !chatId;
   let users = accounts.map((account) => account.id);
-  ipcRenderer.send('message', { message, isNewChat, users, chatId });
+  ipcRenderer.send('message', { message, isNewChat, users, chatId, trackerKey });
 }
 
 function submitMessage (chat_) {
   let input = document.querySelector(MSG_INPUT_SELECTOR);
   let message = input.value;
+  const sendingAt = new Date();
+  const tackerKey = sendingAt.getTime();
   if (message.trim()) {
-    sendMessage(message, chat_.accounts, chat_.id);
+    sendMessage(message, chat_.accounts, chat_.id, tackerKey);
     resetMessageTextArea();
+    const sendingNow = createSendingMessage(message, 'text', tackerKey);
+    queueInSending(chat_.id, sendingNow);
+
+    //Rendering current text
     let div = renderMessage(message, 'outward');
     let msgContainer = document.querySelector('.chat .messages');
-
     msgContainer.appendChild(div);
     scrollToChatBottom();
   }
@@ -332,4 +337,37 @@ function resetChatScreen () {
   removeSubmitHandler();
   window.currentChatId = null;
   window.chat = {};
+}
+
+function queueInSending (chatId, message) {
+  if (!chatId) {
+    chatId = 'new-chat';
+  }
+  if (!window.messageInQueue[chatId]) {
+    window.messageInQueue[chatId] = [];
+  }
+  window.messageInQueue[chatId].push(message);
+}
+
+function dequeueFromSending (sentObj) {
+  const { chatId, trackerKey } = sentObj;
+  if (!window.messageInQueue[chatId]) {
+    window.messageInQueue[chatId] = window.messageInQueue['new-chat'];
+    delete window.messageInQueue['new-chat'];
+  }
+  let queue = window.messageInQueue[chatId];
+  queue = queue.filter((messageQueued) => messageQueued.trackerKey !== trackerKey);
+  window.messageInQueue[chatId] = queue;
+}
+
+function createSendingMessage (message, type, trackerKey) {
+  return { _params: 
+    { 
+      text: message,
+      type: type, 
+      accountId: window.loggedInUserId, 
+      created: undefined 
+    },
+  trackerKey
+  };
 }

--- a/browser/js/globals.js
+++ b/browser/js/globals.js
@@ -14,6 +14,7 @@ window.unreadChats = {};
 window.chat = {};
 window.chatUsers = {};
 window.currentChatId = null;
+window.messageInQueue = {};
 window.notifiedChatId = null;
 window.loggedInUserId = null;
 window.loggedInUser = null;

--- a/browser/js/index.js
+++ b/browser/js/index.js
@@ -78,8 +78,14 @@ document.addEventListener('DOMContentLoaded', () => {
       getIsSeenText(chat_) != getIsSeenText(window.chat) ||
       chat_.items[0].id != chat_._params.lastSeenAt[window.loggedInUserId].item_id
     );
-
-    if (isNewMessage && isCurrentChat(chat_) && !window.gettingOlderMessages) renderChat(chat_);
+    let currentChat = isCurrentChat(chat_);
+    if (currentChat) {
+      // reassign currentChatId, for cases of new chats/dummy chats.
+      window.currentChatId = chat_.id;
+    }
+    if (isNewMessage && currentChat && !window.gettingOlderMessages) {
+      renderChat(chat_);
+    }
   });
 
   ipcRenderer.on('olderMessages', (_, {chatId, messages}) => {
@@ -107,6 +113,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   ipcRenderer.on('getDisplayPictureUrl', (evt, displayPicture) => {
     renderDisplayPicture(displayPicture);
+  });
+
+  ipcRenderer.on('messageSent', (evt, messageToDequeue) => {
+    dequeueFromSending(messageToDequeue);
   });
 
   document.querySelector('button.open-emoji').onclick = () => {

--- a/browser/js/renderers.js
+++ b/browser/js/renderers.js
@@ -349,6 +349,7 @@ function renderChat (chat_, loadingMore) {
   let messages = chat_.items.slice().reverse();
   // load older messages if they exist too
   messages = (window.olderMessages[chat_.id] || []).slice().reverse().concat(messages);
+  messages = window.messageInQueue[chat_.id] ? messages.concat(window.messageInQueue[chat_.id]): messages;
   messages.forEach((message) => {
     let div = renderMessage(message, getMsgDirection(message),
       message._params.created, message._params.type

--- a/main/main.js
+++ b/main/main.js
@@ -269,14 +269,21 @@ electron.ipcMain.on('getOlderMessages', (_, id) => {
     });
 });
 
+function messageSent (chatId, trackerKey) {
+  mainWindow.webContents.send('messageSent', {chatId, trackerKey});
+}
+
 electron.ipcMain.on('message', (_, data) => {
+  const messageTracker = data.trackerKey;
   if (data.isNewChat) {
     instagram.sendNewChatMessage(session, data.message, data.users).then((chat) => {
+      messageSent(chat[0].id, messageTracker);
       getChat(null, chat[0].id);
       getChatList();
     });
   } else {
     instagram.sendMessage(session, data.message, data.chatId).then(() => {
+      messageSent(data.chatId, messageTracker);
       getChat(null, data.chatId);
       getChatList();
     });


### PR DESCRIPTION
Closes: #1255 

**Issue:**
When we send multiple messages we render for each message sent, which occurs in all the message to take appear at once.

**Fix**
Track when to re-render the chat screen.

**Preview**
![fix-to-delay](https://user-images.githubusercontent.com/15632559/77237383-b9644980-6bed-11ea-8418-19c2fce1e022.gif)
