### PR TITLE
Seen tag shown on right side

### DIFF
--- a/browser/css/app.css
+++ b/browser/css/app.css
@@ -303,6 +303,7 @@ button, button:focus {
   color: #aaa;
   font-size: 0.75rem;
   font-style: normal;
+  margin-left: auto;
 }
 
 .heart{


### PR DESCRIPTION
Minor fix to make the "seen" tag be showed on the right side of the screen, as the official app does. Currently they're showed on the left side, as they were related to the othe person's messages. 