### PR TITLE
[Fix] Null check required under User.Presence Object

### DIFF
--- a/browser/css/app.css
+++ b/browser/css/app.css
@@ -181,6 +181,17 @@ button, button:focus {
   border-bottom: 1px #EFEFEF solid;
 }
 
+.chat-subtitle {
+  color: #666;
+  text-transform: capitalize;
+  font-size: 12px;
+  margin: 0;
+}
+
+.chat-subtitle > .active {
+  color: green;
+}
+
 .chat-title b:hover {
   cursor: pointer;
   text-decoration: underline;

--- a/browser/js/funcs.js
+++ b/browser/js/funcs.js
@@ -11,6 +11,9 @@ function format (number) {
 }
 
 function formatTime (unixTime) {
+  if (unixTime == null) {
+    return;
+  }
   const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
     'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
   let date = new Date(parseInt(unixTime.toString().slice(0, 13)));

--- a/browser/js/renderers.js
+++ b/browser/js/renderers.js
@@ -365,15 +365,21 @@ function renderChatList (chatList) {
   });
 }
 
+function getLastSeenText (formatedTime) {
+  if (formatedTime) {
+    return `Last seen ${formatedTime}`;
+  }
+  return '--';
+}
+
 function renderChatHeader (chat_) {
   let chatTitle = (chat_.thread_id ? getChatTitle(chat_) : getUsernames(chat_)); // if chat_.thread_id is not defined, it is a new contact
-  
-  if (Object.prototype.hasOwnProperty.call(chat_, 'presence')) {
-    let timeFormat = chat_.presence.is_active? 'Active now' : `Last seen ${formatTime(chat_.presence.last_activity_at_ms)}`;
 
+  if (Object.prototype.hasOwnProperty.call(chat_, 'presence')) {
+    let timeFormat = chat_.presence.isActive? '<span class="active"> &#9679;</span> Active now' : `${getLastSeenText(formatTime(chat_.presence.last_activity_at_ms))}`;
     b = document.createElement('div');
     b.appendChild(dom(`<b class="ml-2">${chatTitle}</b>`));
-    b.appendChild(dom(`<p class="ml-2">${timeFormat}</b>`));
+    b.appendChild(dom(`<p class="ml-2 chat-subtitle">${timeFormat}</b>`));
   } else {
     b = dom(`<b class="ml-2 mt-2">${chatTitle}</b>`);
   }

--- a/main/instagram.js
+++ b/main/instagram.js
@@ -229,8 +229,8 @@ exports.getUser = function (userId) {
   });
 };
 
-exports.getPresence = function() {
+exports.getPresence = function () {
   return new Promise((resolve, reject) => {
     igClient.direct.getPresence().then(resolve).catch(reject);
-  })
-}
+  });
+};

--- a/main/main.js
+++ b/main/main.js
@@ -76,8 +76,8 @@ function getChatList () {
     }
 
     instagram.getPresence().then((presenceInfo) => {
-      for(let chat in chats){
-        if(chats[chat].users.length === 1 && Object.prototype.hasOwnProperty.call(presenceInfo.user_presence, chats[chat].users[0].pk)){
+      for (const chat in chats) {
+        if (chats[chat].users.length === 1 && Object.prototype.hasOwnProperty.call(presenceInfo.user_presence, chats[chat].users[0].pk)) {
           chats[chat].presence = presenceInfo.user_presence[chats[chat].users[0].pk];
         }
       }


### PR DESCRIPTION
Few of the Instagram accounts don't support `presence.last_activity_at_ms` even when `chat_.presence` is an Object.

Issue while rendering chat for that account:
1. Unable to open those chats which have `null` value for` presence.last_activity_at_ms`
![Screenshot from 2020-04-21 01-39-25](https://user-images.githubusercontent.com/15632559/79800812-8e028500-837a-11ea-97c9-7f82dc6e8e18.png)

UI-Fixes:

1. The text are rendering in big size, and taking extra header.
![Screenshot from 2020-04-21 02-50-19](https://user-images.githubusercontent.com/15632559/79800986-eafe3b00-837a-11ea-8ab3-8552d7836a5a.png)

Updated:
![Screenshot from 2020-04-21 02-49-13](https://user-images.githubusercontent.com/15632559/79801038-ffdace80-837a-11ea-9917-c1382f9a3fc3.png)
![Screenshot from 2020-04-21 02-49-48](https://user-images.githubusercontent.com/15632559/79801046-023d2880-837b-11ea-96af-b8962c614b7e.png)
