### PR TITLE
Enable Configurations menu on DEV

### DIFF
--- a/main/main.js
+++ b/main/main.js
@@ -178,12 +178,11 @@ app.on('ready', () => {
   createWindow();
   // only set the menu template when in production mode/
   // this also leaves the dev console enabled when in dev mode.
-  if (!process.defaultApp) {
-    createMenuTemplate().then((template) => {
-      const menu = Menu.buildFromTemplate(template);
-      Menu.setApplicationMenu(menu);
-    });
-  }
+  const baseMenu = (process.defaultApp ? Menu.getApplicationMenu().items : null);
+  createMenuTemplate(baseMenu).then((template) => {
+    const menu = Menu.buildFromTemplate(template);
+    Menu.setApplicationMenu(menu);
+  });
   if (autoUpdatePreference.autoUpdateStatus) {
     autoUpdater.init();
   }

--- a/main/menutemplate.js
+++ b/main/menutemplate.js
@@ -107,10 +107,11 @@ if (process.platform === 'darwin') {
   ];
 }
 
-const createMenuTemplate = () => {
+const createMenuTemplate = (baseTemplate) => {
+  const _template = baseTemplate || template;
   return new Promise((resolve) => {
     autoLaunch.autoLaunchStatus().then((autoLaunchStatus) => {
-      template.splice(-2, 0,
+      _template.splice(-2, 0,
         {
           label: 'Configurations',
           submenu: [
@@ -129,7 +130,7 @@ const createMenuTemplate = () => {
           ]
         }
       );
-      resolve(template);
+      resolve(_template);
     });
   });
 };


### PR DESCRIPTION
Refactor the createTemplate function to accept a base template. With the change, we can pass the default base menu on dev and extend by adding the "Configurations" menu, while on prod we keep the fully customized menu.