### PR TITLE
Update the 2FA Popup Text

### DIFF
--- a/browser/views/twofactor.pug
+++ b/browser/views/twofactor.pug
@@ -7,7 +7,7 @@ block content
   .container.cardBox.pb-5.pt-3.pt-sm-5
     form.pageCard.mx-auto.p-4.p-sm-5
       .clearfix.welcomeBox
-        span.d-block.text-center Please enter the verification code sent to your phone no.
+        span.d-block.text-center Please enter the verification code sent to your phone number or 2FA app.
       .input-group.loginInputs.mt-4
         input.form-control.code(type='text', name='code', required='true', placeholder='Code')
       button.loginButton.mt-3.btn.btn-primary(type='submit') Submit Code


### PR DESCRIPTION
Added clarification to the 2FA popup by changing the text to ask for the code sent to the phone number or 2FA app rather than just the phone no.